### PR TITLE
Fixed deprecation messages

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ define(function (require, exports, module) {
     var CommandManager = brackets.getModule("command/CommandManager"),
         Menus = brackets.getModule("command/Menus"),
         DocumentManager = brackets.getModule("document/DocumentManager"),
-        EditorManager = brackets.getModule("editor/EditorManager"),
+        WorkspaceManager = brackets.getModule("view/WorkspaceManager"),
         ExtensionUtils = brackets.getModule("utils/ExtensionUtils"),
         NodeConnection = brackets.getModule("utils/NodeConnection"),
         ProjectManager = brackets.getModule("project/ProjectManager"),
@@ -176,11 +176,11 @@ define(function (require, exports, module) {
         show: function (command) {
             this.panel.style.display = "block";
             this.commandTitle.textContent = command;
-            EditorManager.resizeEditor();
+            WorkspaceManager.recomputeLayout();
         },
         hide: function () {
             this.panel.style.display = "none";
-            EditorManager.resizeEditor();
+            WorkspaceManager.recomputeLayout();
         },
         clear: function () {
             this.pre.innerHTML = null;
@@ -215,7 +215,7 @@ define(function (require, exports, module) {
 
             var h = Panel.height + (Panel.y - e.pageY);
             Panel.panel.style.height = h + "px";
-            EditorManager.resizeEditor();
+            WorkspaceManager.recomputeLayout();
 
         },
         mouseup: function (e) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "1.2.0",
   "license": "MIT",
   "engines": {
-    "brackets": ">=0.30.0"
+    "brackets": ">=0.44.0"
   },
   "keywords": [
     "node",


### PR DESCRIPTION
44 is where it is deprecated. Set that as requirement version.
You might want to raise it to 1.0.0, as I've tested this with that version. And it's working on the new brackets version.

See:
http://brackets.io/docs/current/modules/editor/EditorManager.html#-resizeEditor
