### PR TITLE
Terminal force to bottom and line wrap on/off.

### DIFF
--- a/html/modal-settings.html
+++ b/html/modal-settings.html
@@ -24,6 +24,8 @@
         <td>
             <div class="field-container">
                 <label>Autoscroll in terminal: <input type="checkbox" class="autoscroll"></label>
+                <label>Force terminal to bottom of brackets: <input type="checkbox" class="termbottom"></label>
+                <label>Wrap terminal output: <input type="checkbox" class="wrap"></label>
             </div>
         </td>
     </tr>

--- a/preferences.js
+++ b/preferences.js
@@ -6,6 +6,8 @@ define(function main(require, exports, module) {
     prefs.definePreference("node-bin", "string", "");
     prefs.definePreference("npm-bin", "string", "");
     prefs.definePreference("autoscroll", "boolean", true);
+    prefs.definePreference("termbottom", "boolean", true);
+    prefs.definePreference("wrap", "boolean", false);
     prefs.definePreference("v8-flags", "string", "");
 
     // Conversion from the old localstorage


### PR DESCRIPTION
The current version puts the terminal below the status bar, which is a bit wierd. This version puts the terminal in the normal extension window stack, but allows it to be configured to be the bottom one of those.
It also includes an option to turn off word wrap in the terminal.