### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Brackets-Node.js (Node.js bindings)
+# Brackets-Node.js (Node.js bindings)
 ... is an extension for Brackets to run Node.js or NPM files directly from Brackets.
 
 ![Extension in work](preview.png)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
